### PR TITLE
[List] 상품등록 버튼 기능 구현 및 상품등록 페이지와 연결

### DIFF
--- a/lib/pages/list/list_page.dart
+++ b/lib/pages/list/list_page.dart
@@ -1,6 +1,7 @@
 import 'package:flowerring/model/product.dart';
 import 'package:flowerring/pages/detail/detail_page.dart';
 import 'package:flowerring/pages/list/widgets/product_item.dart';
+import 'package:flowerring/pages/registration/registration_page.dart';
 import 'package:flutter/material.dart';
 
 class ListPage extends StatelessWidget {
@@ -11,6 +12,19 @@ class ListPage extends StatelessWidget {
     // Product.getProducts()로 상품 데이터 가져오기
     final List<Product> items = Product.getProducts();
     return Scaffold(
+      // 상품 등록 버튼 클릭 시 등록 페이지 이동
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) {
+                return RegistrationPage();
+              },
+            ),
+          );
+        },
+      ),
       appBar: AppBar(
         centerTitle: true,
         title: const Text('플라워링'),

--- a/lib/pages/list/list_page.dart
+++ b/lib/pages/list/list_page.dart
@@ -14,6 +14,10 @@ class ListPage extends StatelessWidget {
     return Scaffold(
       // 상품 등록 버튼 클릭 시 등록 페이지 이동
       floatingActionButton: FloatingActionButton(
+        backgroundColor: Color.fromRGBO(255, 118, 118, 1),
+        foregroundColor: Colors.white,
+        child: Icon(Icons.add),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
         onPressed: () {
           Navigator.push(
             context,


### PR DESCRIPTION
### 🚀 개요
상품 등록 버튼을 눌러 상품등록 페이지에 들어갈 수 있다.

### 🔧 변경사항
- 상품등록 버튼을 floatingActionButton으로 만들었다.
- 버튼의 디자인은 지정된 색인 Color.fromRGBO(255, 118, 118, 1) 값을 사용하였다.
- 상품등록 버튼 안에 추가를 나타내는 add 아이콘을 하얀색으로 넣었다.

### 실행 화면
<img src="https://github.com/user-attachments/assets/7dfca248-7dee-45de-be58-50bbefcb95e1" width="300" height="600"/>

### 💡issue : #9
