### PR TITLE
[Cart] 장바구니에 담긴 상품 표시

### DIFF
--- a/lib/model/cart_item.dart
+++ b/lib/model/cart_item.dart
@@ -2,7 +2,7 @@ import 'package:flowerring/model/product.dart';
 
 class CartItem {
   final Product product;
-  final int quantity;
+  int quantity;
 
   CartItem({required this.product, required this.quantity});
 }

--- a/lib/model/cart_item.dart
+++ b/lib/model/cart_item.dart
@@ -27,4 +27,13 @@ class Cart {
   void addProduct(Product product, int quantity) {
     _itemsInCart.add(CartItem(product: product, quantity: quantity));
   }
+
+  int getTotalPrice() {
+    int totalPrice = 0;
+
+    for(final item in items) {
+      totalPrice += item.product.price * item.quantity;
+    }
+    return totalPrice;
+  }
 }

--- a/lib/model/cart_item.dart
+++ b/lib/model/cart_item.dart
@@ -28,6 +28,10 @@ class Cart {
     _itemsInCart.add(CartItem(product: product, quantity: quantity));
   }
 
+  void removeProduct(CartItem product) {
+    _itemsInCart.remove(product);
+  }
+
   int getTotalPrice() {
     int totalPrice = 0;
 

--- a/lib/pages/cart/cart_page.dart
+++ b/lib/pages/cart/cart_page.dart
@@ -73,6 +73,19 @@ class _CartPageState extends State<CartPage> {
               width: double.infinity,
               child: _payButton(),
             ),
+    );
+  }
+
+  Widget _emptyCartMessage() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.shopping_cart_outlined, size: 80, color: Colors.grey),
+          SizedBox(height: 16),
+          Text(
+            '상품이 없습니다.',
+            style: TextStyle(fontSize: 18, color: Colors.grey),
           ),
         ],
       ),

--- a/lib/pages/cart/cart_page.dart
+++ b/lib/pages/cart/cart_page.dart
@@ -55,7 +55,10 @@ class _CartPageState extends State<CartPage> {
                 }
                 return Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: ItemInCart(item: cartItems[index]),
+                  child: ItemInCart(
+                    item: cartItems[index],
+                    onCartChanged: () => setState(() {}),
+                  ),
                 );
               },
             ),

--- a/lib/pages/cart/cart_page.dart
+++ b/lib/pages/cart/cart_page.dart
@@ -1,5 +1,4 @@
 import 'package:flowerring/model/cart_item.dart';
-import 'package:flowerring/model/product.dart';
 import 'package:flutter/material.dart';
 import 'package:flowerring/pages/cart/widgets/item_in_cart.dart';
 import 'package:flowerring/pages/cart/widgets/payment_summary.dart';

--- a/lib/pages/cart/cart_page.dart
+++ b/lib/pages/cart/cart_page.dart
@@ -54,7 +54,7 @@ class _CartPageState extends State<CartPage> {
                 }
                 return Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: ItemInCart(),
+                  child: ItemInCart(item: cartItems[index]),
                 );
               },
             ),

--- a/lib/pages/cart/cart_page.dart
+++ b/lib/pages/cart/cart_page.dart
@@ -15,9 +15,9 @@ class _CartPageState extends State<CartPage> {
 
   @override
   Widget build(BuildContext context) {
-    final cartItems = Cart().items; // 싱글톤 Cart에서 가져오기
-    final itemCount = cartItems.length;
-    final int productPrice = Cart().getTotalPrice();
+    final cart = Cart();
+    final cartItems = cart.items;
+    final productPrice = cart.getTotalPrice();
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -34,45 +34,10 @@ class _CartPageState extends State<CartPage> {
         // 스크롤해도 색상이 달라지지 않도록 설정
         scrolledUnderElevation: 0,
       ),
-      body: Column(
-        children: [
-          Expanded(
-            child: ListView.builder(
-              padding: EdgeInsets.symmetric(horizontal: 16),
-              itemCount: itemCount + 1,
-              itemBuilder: (context, index) {
-                if (index == itemCount) {
-                  // item이 모두 표시되면 마지막으로 결제 정보 표시
-                  return Column(
-                    children: [
-                      PaymentSummary(
-                        productPrice: productPrice,
-                        deliveryFee: deliveryFee,
-                      ),
-                    ],
-                  );
-                }
-                return Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: ItemInCart(
-                    item: cartItems[index],
-                    onCartChanged: () => setState(() {}),
-                  ),
-                );
-              },
-            ),
-          ),
-
-          Padding(
-            padding: const EdgeInsets.only(
-              left: 12.0,
-              right: 12.0,
-              bottom: 12.0,
-            ),
-            child: SizedBox(
-              width: double.infinity,
-              child: _payButton(),
-            ),
+      body:
+          cartItems.isEmpty
+              ? _emptyCartMessage()
+              : _itemInCart(cartItems, productPrice),
     );
   }
 
@@ -89,6 +54,48 @@ class _CartPageState extends State<CartPage> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _itemInCart(List<CartItem> cartItems, int productPrice) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            itemCount: cartItems.length + 1,
+            itemBuilder: (context, index) {
+              if (index == cartItems.length) {
+                // item이 모두 표시되면 마지막으로 결제 정보 표시
+                return Column(
+                  children: [
+                    PaymentSummary(
+                      productPrice: productPrice,
+                      deliveryFee: deliveryFee,
+                    ),
+                  ],
+                );
+              }
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: ItemInCart(
+                  item: cartItems[index],
+                  onCartChanged: () => setState(() {}),
+                ),
+              );
+            },
+          ),
+        ),
+
+        Padding(
+          padding: const EdgeInsets.only(
+            left: 12.0,
+            right: 12.0,
+            bottom: 12.0,
+          ),
+          child: SizedBox(width: double.infinity, child: _payButton()),
+        ),
+      ],
     );
   }
 

--- a/lib/pages/cart/cart_page.dart
+++ b/lib/pages/cart/cart_page.dart
@@ -12,13 +12,13 @@ class CartPage extends StatefulWidget {
 }
 
 class _CartPageState extends State<CartPage> {
-  final itemCount = 5;
   final int productPrice = 20600;
   final int deliveryFee = 0;
 
   @override
   Widget build(BuildContext context) {
     final cartItems = Cart().items; // 싱글톤 Cart에서 가져오기
+    final itemCount = cartItems.length;
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
@@ -66,7 +66,10 @@ class _CartPageState extends State<CartPage> {
               right: 12.0,
               bottom: 12.0,
             ),
-            child: SizedBox(width: double.infinity, child: _payButton()),
+            child: SizedBox(
+              width: double.infinity,
+              child: _payButton(),
+            ),
           ),
         ],
       ),
@@ -79,7 +82,9 @@ class _CartPageState extends State<CartPage> {
       style: ElevatedButton.styleFrom(
         foregroundColor: Colors.white,
         backgroundColor: const Color.fromRGBO(255, 118, 118, 1.0),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
       ),
       child: const Text(
         '결제하기',

--- a/lib/pages/cart/cart_page.dart
+++ b/lib/pages/cart/cart_page.dart
@@ -12,13 +12,14 @@ class CartPage extends StatefulWidget {
 }
 
 class _CartPageState extends State<CartPage> {
-  final int productPrice = 20600;
   final int deliveryFee = 0;
 
   @override
   Widget build(BuildContext context) {
     final cartItems = Cart().items; // 싱글톤 Cart에서 가져오기
     final itemCount = cartItems.length;
+    final int productPrice = Cart().getTotalPrice();
+
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -3,8 +3,13 @@ import 'package:flutter/material.dart';
 
 class ItemInCart extends StatefulWidget {
   final CartItem item;
+  final VoidCallback onCartChanged;
 
-  const ItemInCart({super.key, required this.item});
+  const ItemInCart({
+    super.key,
+    required this.item,
+    required this.onCartChanged,
+  });
 
   @override
   State<ItemInCart> createState() => _ItemInCartState();

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -16,6 +16,19 @@ class ItemInCart extends StatefulWidget {
 }
 
 class _ItemInCartState extends State<ItemInCart> {
+  void _changeQuantity(bool increment) {
+    setState(() {
+      if (increment) {
+        widget.item.quantity++;
+      } else {
+        if (widget.item.quantity > 1) {
+          widget.item.quantity--;
+        }
+      }
+    });
+    widget.onCartChanged();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -31,7 +31,7 @@ class ItemInCart extends StatelessWidget {
 
             Column(
               crossAxisAlignment: CrossAxisAlignment.end,
-              children: [SizedBox(height: 40), _itemCounter()],
+              children: [SizedBox(height: 40), _itemCounter(item.quantity)],
             ),
           ],
         ),
@@ -64,12 +64,12 @@ class ItemInCart extends StatelessWidget {
     return Text('$price원');
   }
 
-  Widget _itemCounter() {
+  Widget _itemCounter(int quantity) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         _quantityStepButton(Icons.remove),
-        _countValueBox('1'),
+        _countValueBox(quantity),
         _quantityStepButton(Icons.add),
       ],
     );
@@ -107,7 +107,7 @@ class ItemInCart extends StatelessWidget {
     );
   }
 
-  Widget _countValueBox(String count) {
+  Widget _countValueBox(int quantity) {
     return Container(
       width: 36,
       height: 36,
@@ -118,7 +118,7 @@ class ItemInCart extends StatelessWidget {
           bottom: BorderSide(color: Colors.grey[300]!),
         ),
       ),
-      child: Text(count, style: const TextStyle(fontSize: 14)),
+      child: Text('$quantity', style: const TextStyle(fontSize: 14)),
     );
   }
 

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -20,7 +20,7 @@ class ItemInCart extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
-                _itemTitle(),
+                _itemTitle(item.product.title),
                 SizedBox(height: 20),
                 _itemPrice(),
               ],
@@ -50,9 +50,9 @@ class ItemInCart extends StatelessWidget {
     );
   }
 
-  Widget _itemTitle() {
+  Widget _itemTitle(String title) {
     return Text(
-      '아이폰 15PRO 금처합니다.',
+      title,
       style: TextStyle(fontWeight: FontWeight.bold),
     );
   }

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -1,11 +1,16 @@
 import 'package:flowerring/model/cart_item.dart';
 import 'package:flutter/material.dart';
 
-class ItemInCart extends StatelessWidget {
+class ItemInCart extends StatefulWidget {
   final CartItem item;
 
   const ItemInCart({super.key, required this.item});
 
+  @override
+  State<ItemInCart> createState() => _ItemInCartState();
+}
+
+class _ItemInCartState extends State<ItemInCart> {
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -22,16 +27,16 @@ class ItemInCart extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
-                  _itemTitle(item.product.title),
+                  _itemTitle(widget.item.product.title),
                   SizedBox(height: 20),
-                  _itemPrice(item.product.price * item.quantity),
+                  _itemPrice(widget.item.product.price * widget.item.quantity),
                 ],
               ),
             ),
 
             Column(
               crossAxisAlignment: CrossAxisAlignment.end,
-              children: [SizedBox(height: 40), _itemCounter(item.quantity)],
+              children: [SizedBox(height: 40), _itemCounter(widget.item.quantity)],
             ),
           ],
         ),

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -24,7 +24,7 @@ class ItemInCart extends StatelessWidget {
                 children: [
                   _itemTitle(item.product.title),
                   SizedBox(height: 20),
-                  _itemPrice(item.product.price),
+                  _itemPrice(item.product.price * item.quantity),
                 ],
               ),
             ),

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -16,14 +16,17 @@ class ItemInCart extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             _productImage(),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.start,
-              children: [
-                _itemTitle(item.product.title),
-                SizedBox(height: 20),
-                _itemPrice(item.product.price),
-              ],
+            SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  _itemTitle(item.product.title),
+                  SizedBox(height: 20),
+                  _itemPrice(item.product.price),
+                ],
+              ),
             ),
 
             Column(

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -164,7 +164,7 @@ class _ItemInCartState extends State<ItemInCart> {
 
   Widget _closeButton() {
     return GestureDetector(
-      onTap: () {},
+      onTap: _removeProduct,
       child: Icon(Icons.close, size: 20),
     );
   }

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -22,7 +22,7 @@ class ItemInCart extends StatelessWidget {
               children: [
                 _itemTitle(item.product.title),
                 SizedBox(height: 20),
-                _itemPrice(),
+                _itemPrice(item.product.price),
               ],
             ),
 
@@ -57,8 +57,8 @@ class ItemInCart extends StatelessWidget {
     );
   }
 
-  Widget _itemPrice() {
-    return Text('153,300원');
+  Widget _itemPrice(int price) {
+    return Text('$price원');
   }
 
   Widget _itemCounter() {

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -1,7 +1,10 @@
+import 'package:flowerring/model/cart_item.dart';
 import 'package:flutter/material.dart';
 
 class ItemInCart extends StatelessWidget {
-  const ItemInCart({super.key});
+  final CartItem item;
+
+  const ItemInCart({super.key, required this.item});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -47,14 +47,20 @@ class _ItemInCartState extends State<ItemInCart> {
                 children: [
                   _itemTitle(widget.item.product.title),
                   SizedBox(height: 20),
-                  _itemPrice(widget.item.product.price * widget.item.quantity),
+                  _itemPrice(
+                    widget.item.product.price *
+                        widget.item.quantity,
+                  ),
                 ],
               ),
             ),
 
             Column(
               crossAxisAlignment: CrossAxisAlignment.end,
-              children: [SizedBox(height: 40), _itemCounter(widget.item.quantity)],
+              children: [
+                SizedBox(height: 40),
+                _itemCounter(widget.item.quantity),
+              ],
             ),
           ],
         ),
@@ -91,21 +97,24 @@ class _ItemInCartState extends State<ItemInCart> {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        _quantityStepButton(Icons.remove),
-        _countValueBox(quantity),
-        _quantityStepButton(Icons.add),
+        _quantityStepButton(Icons.remove, false),
+        _countValueBox(widget.item.quantity),
+        _quantityStepButton(Icons.add, true),
       ],
     );
   }
 
-  Widget _quantityStepButton(IconData icon) {
+  Widget _quantityStepButton(IconData icon, bool increment) {
     return Container(
       width: 36,
       height: 36,
       decoration: BoxDecoration(
         border: Border.all(color: Colors.grey[300]!),
       ),
-      child: IconButton(icon: Icon(icon, size: 16), onPressed: () {}),
+      child: IconButton(
+        icon: Icon(icon, size: 16),
+        onPressed: () => _changeQuantity(increment),
+      ),
     );
   }
 
@@ -141,7 +150,10 @@ class _ItemInCartState extends State<ItemInCart> {
           bottom: BorderSide(color: Colors.grey[300]!),
         ),
       ),
-      child: Text('$quantity', style: const TextStyle(fontSize: 14)),
+      child: Text(
+        '$quantity',
+        style: const TextStyle(fontSize: 14),
+      ),
     );
   }
 

--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -29,6 +29,11 @@ class _ItemInCartState extends State<ItemInCart> {
     widget.onCartChanged();
   }
 
+  void _removeProduct() {
+    Cart().removeProduct(widget.item);
+    widget.onCartChanged();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Column(


### PR DESCRIPTION
### 🚀 개요
장바구니 화면에서 장바구니에 담긴 상품들의 수량을 조절하고, 제거할 수 있다.

### 🔧 변경사항
- 장바구니에 담긴 상품 표시
- x를 터치하면 장바구니에서 상품 제거
- '+' '-' 로 상품 수량 조절
- 장바구니가 비어있으면 '장바구니가 비어있습니다.' 메세지 표시
- 상품 수량에 따른 결제 금액 표시

### 실행 화면
<img src="https://github.com/user-attachments/assets/0375ad76-4074-4fb7-9175-8ee6f05ed5b9" width="300" height="600"/>
<img src="https://github.com/user-attachments/assets/e9e929d6-440e-4e93-a3c8-90bb390e52a1" width="300" height="600"/>

### 💡issue : #73 
