### PR TITLE
[Cart] 장바구니에 담긴 상품 중복 담기

### DIFF
--- a/lib/model/cart_item.dart
+++ b/lib/model/cart_item.dart
@@ -29,7 +29,12 @@ class Cart {
     final existingItem = _itemsInCart.firstWhereOrNull(
       (item) => item.product.id == product.id,
     );
-    _itemsInCart.add(CartItem(product: product, quantity: quantity));
+
+    if (existingItem != null) {
+      existingItem.quantity += quantity;
+    } else {
+      _itemsInCart.add(CartItem(product: product, quantity: quantity));
+    }
   }
 
   void removeProduct(CartItem product) {

--- a/lib/model/cart_item.dart
+++ b/lib/model/cart_item.dart
@@ -1,4 +1,5 @@
 import 'package:flowerring/model/product.dart';
+import 'package:collection/collection.dart';
 
 class CartItem {
   final Product product;
@@ -25,6 +26,9 @@ class Cart {
   List<CartItem> get items => _itemsInCart;
 
   void addProduct(Product product, int quantity) {
+    final existingItem = _itemsInCart.firstWhereOrNull(
+      (item) => item.product.id == product.id,
+    );
     _itemsInCart.add(CartItem(product: product, quantity: quantity));
   }
 
@@ -35,7 +39,7 @@ class Cart {
   int getTotalPrice() {
     int totalPrice = 0;
 
-    for(final item in items) {
+    for (final item in items) {
       totalPrice += item.product.price * item.quantity;
     }
     return totalPrice;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,7 +34,7 @@ packages:
     source: hosted
     version: "1.1.2"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
 
   cupertino_icons: ^1.0.8
   intl: ^0.20.2
+  collection: ^1.17.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 🚀 개요
이미 장바구니에 담긴 상품이라면 수량만 추가하고,
장바구니에 담기지 않은 상품이라면 장바구니에 상품을 추가한다.

### 🔧 변경사항
- collection 패키지 추가
- 장바구니에 상품이 담겨 있으면  수량만 추가
- 장바구니에 상품이 없으면 상품 추가

### 실행 화면
<img src="https://github.com/user-attachments/assets/fbfc48cf-8f98-4698-acdb-7c3f021150ab" width="300" height="600"/>

### 💡issue : #33 
