### PR TITLE
[List] 예외처리 가격 표시할때 세자리 수 마다 콤마적용

### DIFF
--- a/lib/pages/list/widgets/product_item.dart
+++ b/lib/pages/list/widgets/product_item.dart
@@ -1,3 +1,4 @@
+import 'package:flowerring/utils/format_price.dart';
 import 'package:flutter/material.dart';
 import 'package:flowerring/model/product.dart';
 
@@ -44,7 +45,7 @@ class ProductItem extends StatelessWidget {
                     ),
                     SizedBox(width: 150),
                     Text(
-                      '${product.price}원',
+                      '${formatPrice(product.price)}원',
                       style: TextStyle(
                         fontSize: 15,
                         fontWeight: FontWeight.bold,


### PR DESCRIPTION
### 🚀 개요
예외처리 가격 표시할때 세자리 수 마다 콤마적용

### 🔧 변경사항
- format_price 파일에서 세자리 수 마다 콤마를 넣어주는 함수를 불러와 서 product.price 앞에 넣어 적용 

### 실행 화면
<img src="https://github.com/user-attachments/assets/a92d4bfc-7c18-478f-9655-1d7bbf868c3b" width="300" height="600"/>
이미지 크기 설정

### 💡issue : #13 