### PR TITLE
[Detail] 상세페이지에서 재고 예외처리 팝업설정 

### DIFF
--- a/lib/pages/detail/detail_page.dart
+++ b/lib/pages/detail/detail_page.dart
@@ -21,7 +21,10 @@ class _DetailPageState extends State<DetailPage> {
   @override
   void initState() {
     super.initState();
-    quantityController = QuantityController(unitPrice: widget.product.price);
+    quantityController = QuantityController(
+      unitPrice: widget.product.price,
+      stock: widget.product.stock,
+    );
     quantityController.addListener(() {
       setState(() {}); // 수량 or 가격 변경 시 자동 UI 업데이트
     });

--- a/lib/pages/detail/widgets/product_detail_controller.dart
+++ b/lib/pages/detail/widgets/product_detail_controller.dart
@@ -8,8 +8,9 @@ import 'package:flutter/material.dart';
 class QuantityController extends ChangeNotifier {
   int _quantity = 1;
   int unitPrice;
+  final int stock;
 
-  QuantityController({required this.unitPrice});
+  QuantityController({required this.unitPrice, required this.stock});
 
   ///수량에 따라 자동으로 계산된 가격
   int get quantity => _quantity;
@@ -17,10 +18,12 @@ class QuantityController extends ChangeNotifier {
   ///수량과 총 가격 동시에 반영
   int get totalPrice => _quantity * unitPrice;
 
-  void increment() {
-    if (_quantity < 100) {
+  void increment(BuildContext context) {
+    if (_quantity < stock) {
       _quantity++;
       notifyListeners();
+    } else {
+      _showStockLimitPopup(context);
     }
   }
 
@@ -30,6 +33,26 @@ class QuantityController extends ChangeNotifier {
       notifyListeners();
     }
   }
+}
+
+void _showStockLimitPopup(BuildContext context) {
+  showCupertinoDialog(
+    context: context,
+    builder:
+        (_) => CupertinoAlertDialog(
+          title: Text('알림'),
+          content: Text('재고 수량을 초과할 수 없습니다.'),
+          actions: [
+            CupertinoDialogAction(
+              child: Text('확인'),
+              isDefaultAction: true,
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        ),
+  );
 }
 
 ///ios스타일 팝업 함수

--- a/lib/pages/detail/widgets/product_detail_page.dart
+++ b/lib/pages/detail/widgets/product_detail_page.dart
@@ -54,6 +54,7 @@ class DetailInfoSection extends StatelessWidget {
                 '${formatPrice(controller.totalPrice)}원',
                 style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
               ),
+
               Row(
                 children: [
                   IconButton(
@@ -63,7 +64,7 @@ class DetailInfoSection extends StatelessWidget {
                   Text('${controller.quantity}'),
                   IconButton(
                     icon: const Icon(Icons.add),
-                    onPressed: controller.increment,
+                    onPressed: () => controller.increment(context),
                   ),
                 ],
               ),
@@ -179,7 +180,13 @@ class DetailContentView extends StatelessWidget {
                 ),
                 children: [
                   const SizedBox(height: 8),
-                  Text(product.content),
+
+                  Text(
+                    '재고: ${product.stock}개',
+                    textAlign: TextAlign.right,
+                    style: TextStyle(fontSize: 13),
+                  ),
+                  Text(product.content, style: TextStyle(fontSize: 15)),
 
                   ///Text(product.description), 실제 상품 설명 나중에 설정
                   const SizedBox(height: 8),


### PR DESCRIPTION
### 🚀 개요
상세페이지에서 재고 예외처리 팝업설정 

### 🔧 변경사항
-상세페이지에서 재고 예외처리 팝업설정
-상세페이지 재고 텍스트 설정

### 실행 화면

<img src="https://github.com/user-attachments/assets/c5f9ab21-7941-40bd-89c3-84724ee8e4f6" width="300" height="600"/>
<img src="https://github.com/user-attachments/assets/c30fbf2d-de8f-4f51-9b4b-ee5b5d1300f0" width="300" height="600"/>


### 💡issue : #83 