### PR TITLE
[Cart] 장바구니에 담긴 상품 사진 수정

### DIFF
--- a/lib/pages/cart/widgets/item_in_cart.dart
+++ b/lib/pages/cart/widgets/item_in_cart.dart
@@ -72,7 +72,7 @@ class _ItemInCartState extends State<ItemInCart> {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            _productImage(),
+            _productImage(widget.item),
             SizedBox(width: 12),
             Expanded(
               child: Column(
@@ -104,11 +104,11 @@ class _ItemInCartState extends State<ItemInCart> {
     );
   }
 
-  Widget _productImage() {
+  Widget _productImage(CartItem item) {
     return ClipRRect(
       borderRadius: BorderRadius.circular(8),
       child: Image.asset(
-        'assets/images/bag.png',
+        item.product.imageUrl,
         width: 80,
         height: 80,
         fit: BoxFit.cover,


### PR DESCRIPTION
### 🚀 개요
장바구니에 담긴 상품의 사진을 표시한다.

### 🔧 변경사항
- 사진의 경로를 지정된 경로가 아닌 장바구니에 담긴 상품 경로로 수정

### 실행 화면
<img src="https://github.com/user-attachments/assets/292fd671-94f0-435f-9dd8-4a6c4f110096" width="300" height="600"/>



### 💡issue : #82 
