### PR TITLE
[List] 장바구니 아이콘 선택 시 장바구니 페이지 이동

### DIFF
--- a/lib/pages/list/list_page.dart
+++ b/lib/pages/list/list_page.dart
@@ -1,4 +1,5 @@
 import 'package:flowerring/model/product.dart';
+import 'package:flowerring/pages/cart/cart_page.dart';
 import 'package:flowerring/pages/detail/detail_page.dart';
 import 'package:flowerring/pages/list/widgets/product_item.dart';
 import 'package:flowerring/pages/registration/registration_page.dart';
@@ -39,8 +40,17 @@ class _ListPageState extends State<ListPage> {
         title: const Text('플라워링'),
         actions: [
           IconButton(
-            onPressed: () {},
             icon: Icon(Icons.shopping_cart_outlined),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) {
+                    return CartPage();
+                  },
+                ),
+              );
+            },
           ),
         ],
       ),


### PR DESCRIPTION
### 🚀 개요
리스트페이지에서 장바구니 선택 시 장바구니 페이지로 이동하지 않은 이슈 해결하기

### 🔧 변경사항
- 리스트 페이지에서 장바구니 아이콘 터치시 장바구니 페이지로 이동시킴
### 실행 화면
<img src="https://github.com/user-attachments/assets/8567dc14-d164-4a79-8bc2-0dc48e5f6d13" width="300" height="600"/>
<img src="https://github.com/user-attachments/assets/b2b970ed-631f-4fbf-8655-db5e52df6cd1" width="300" height="600"/>


### 💡issue : #89 