### PR TITLE
[Cart] 결제하기 버튼 클릭 후, AlertDialog 표시

### DIFF
--- a/lib/common/widgets/dialog_helper.dart
+++ b/lib/common/widgets/dialog_helper.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/cupertino.dart';
+
+class DialogHelper {
+  static void showCupertinoYesNoDialog({
+    required BuildContext context,
+    required String title,
+    required String content,
+    VoidCallback? onYes,
+    VoidCallback? onNo,
+    String yesText = '확인',
+    String noText = '취소',
+  }) {
+    showCupertinoDialog(
+      context: context,
+      builder:
+          (_) => CupertinoAlertDialog(
+            title: Text(title),
+            content: Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: Text(content),
+            ),
+            actions: [
+              CupertinoDialogAction(
+                child: Text(noText),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  if (onNo != null) onNo();
+                },
+              ),
+              CupertinoDialogAction(
+                isDefaultAction: true,
+                child: Text(yesText),
+                onPressed: () {
+                  Navigator.of(context).pop();
+                  if (onYes != null) onYes();
+                },
+              ),
+            ],
+          ),
+    );
+  }
+}

--- a/lib/pages/cart/cart_page.dart
+++ b/lib/pages/cart/cart_page.dart
@@ -107,10 +107,8 @@ class _CartPageState extends State<CartPage> {
       onPressed: () {
         widget.onPayment(Cart().items);
         Cart().clearProduct();
-        Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => ListPage()),
-        );
+        Navigator.pop(context);
+        Navigator.pop(context);
       },
       style: ElevatedButton.styleFrom(
         foregroundColor: Colors.white,

--- a/lib/pages/cart/cart_page.dart
+++ b/lib/pages/cart/cart_page.dart
@@ -1,5 +1,5 @@
+import 'package:flowerring/common/widgets/dialog_helper.dart';
 import 'package:flowerring/model/cart_item.dart';
-import 'package:flowerring/pages/list/list_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flowerring/pages/cart/widgets/item_in_cart.dart';
 import 'package:flowerring/pages/cart/widgets/payment_summary.dart';
@@ -105,10 +105,18 @@ class _CartPageState extends State<CartPage> {
   Widget _payButton() {
     return ElevatedButton(
       onPressed: () {
-        widget.onPayment(Cart().items);
-        Cart().clearProduct();
-        Navigator.pop(context);
-        Navigator.pop(context);
+        DialogHelper.showCupertinoYesNoDialog(
+          context: context,
+          title: '결제',
+          content: '결제 하시겠어요?',
+          onYes:
+              () => {
+                widget.onPayment(Cart().items),
+                Cart().clearProduct(),
+                Navigator.pop(context),
+                Navigator.pop(context),
+              },
+        );
       },
       style: ElevatedButton.styleFrom(
         foregroundColor: Colors.white,


### PR DESCRIPTION
### 🚀 개요
결제 버튼 클릭 후, cupertinoDialog를 표시한다.

### 🔧 변경사항
- 확인, 취소 버튼이 있는 CupertinoDialog 위젯 구현
- 결제 버튼 클릭 후, cupertinoDialog 표시
- 결제 완료 후, 현재 화면와 이전 화면을 스택에서 제거

### 실행 화면
<img src="https://github.com/user-attachments/assets/e90ccd65-4a04-434b-b3e7-375f6628a7a1" width="300" height="700"/>


### 💡issue : #96 
