### PR TITLE
[Detail]상세페이지 다크테마 적용,실시간 별점 변경 (리뷰등록에 따른),리뷰총숫자 텍스트 표시

### DIFF
--- a/lib/pages/detail/detail_page.dart
+++ b/lib/pages/detail/detail_page.dart
@@ -21,6 +21,8 @@ class _DetailPageState extends State<DetailPage> {
   late QuantityController quantityController;
 
   int selectedTabIndex = 0; // 0 = 상품설명, 1 = 리뷰
+  double averageRating = 0.0;
+  int totalReviews = 0;
 
   @override
   void initState() {
@@ -38,6 +40,13 @@ class _DetailPageState extends State<DetailPage> {
   void dispose() {
     quantityController.dispose(); // 메모리 누수 방지
     super.dispose();
+  }
+
+  void updateRating(double newAverage, int newTotal) {
+    setState(() {
+      averageRating = newAverage;
+      totalReviews = newTotal;
+    });
   }
 
   Future<bool> handlePurchase() async {
@@ -119,7 +128,12 @@ class _DetailPageState extends State<DetailPage> {
           DetailImageSection(imageUrl: product.imageUrl),
 
           ///상세페이지 이미지
-          DetailInfoSection(product: product, controller: quantityController),
+          DetailInfoSection(
+            product: product,
+            controller: quantityController,
+            averageRating: averageRating,
+            totalReviews: totalReviews,
+          ),
 
           ///상세페이지 정보
           const SizedBox(height: 20),
@@ -130,7 +144,11 @@ class _DetailPageState extends State<DetailPage> {
           ),
 
           ///상세페이지 상품 설명 리뷰 설명
-          DetailContentView(tabIndex: selectedTabIndex, product: product),
+          DetailContentView(
+            tabIndex: selectedTabIndex,
+            product: product,
+            onRatingChanged: updateRating,
+          ),
           SizedBox(height: 30),
           Divider(height: 1),
         ],

--- a/lib/pages/detail/widgets/product_detail_controller.dart
+++ b/lib/pages/detail/widgets/product_detail_controller.dart
@@ -119,8 +119,10 @@ void showPaymentConfirmationDialog(
   );
 }
 
-///별 위젯
-Widget starScore(double rating) {
+/// 별 위젯
+Widget starScore(BuildContext context, double rating) {
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+
   return Row(
     mainAxisSize: MainAxisSize.min,
     children: [
@@ -137,7 +139,10 @@ Widget starScore(double rating) {
       const SizedBox(width: 4),
       Text(
         rating.toStringAsFixed(1),
-        style: const TextStyle(fontSize: 13, color: Colors.black),
+        style: TextStyle(
+          fontSize: 13,
+          color: isDark ? Colors.white : Colors.black, // 다크모드 대응
+        ),
       ),
     ],
   );

--- a/lib/pages/detail/widgets/product_detail_page.dart
+++ b/lib/pages/detail/widgets/product_detail_page.dart
@@ -198,7 +198,7 @@ class DetailTabSelector extends StatelessWidget {
 class DetailContentView extends StatefulWidget {
   final int tabIndex;
   final Product product;
-  final Function(double averageRating, int totalReviews) onRatingChanged; //
+  final Function(double averageRating, int totalReviews) onRatingChanged;
 
   const DetailContentView({
     required this.tabIndex,

--- a/lib/pages/detail/widgets/product_detail_page.dart
+++ b/lib/pages/detail/widgets/product_detail_page.dart
@@ -92,6 +92,9 @@ class DetailTabSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    ///현재 테마가 다크모드인지 확인
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return Column(
       children: [
         // 탭 선택 영역
@@ -107,7 +110,12 @@ class DetailTabSelector extends StatelessWidget {
                       textAlign: TextAlign.center,
                       style: TextStyle(
                         fontWeight: FontWeight.bold,
-                        color: selectedTab == 0 ? Colors.black : Colors.grey,
+
+                        ///선택된 탭일 때 다크모드는 흰색, 라이트모드는 검정색
+                        color:
+                            selectedTab == 0
+                                ? (isDark ? Colors.white : Colors.black)
+                                : Colors.grey,
                       ),
                     ),
                     const SizedBox(height: 8),
@@ -125,7 +133,11 @@ class DetailTabSelector extends StatelessWidget {
                       textAlign: TextAlign.center,
                       style: TextStyle(
                         fontWeight: FontWeight.bold,
-                        color: selectedTab == 1 ? Colors.black : Colors.grey,
+                        // 선택된 탭일 때 다크모드는 흰색, 라이트모드는 검정색
+                        color:
+                            selectedTab == 1
+                                ? (isDark ? Colors.white : Colors.black)
+                                : Colors.grey,
                       ),
                     ),
                     const SizedBox(height: 8),
@@ -141,7 +153,8 @@ class DetailTabSelector extends StatelessWidget {
             Container(
               height: 2,
               width: double.infinity,
-              color: Colors.grey.shade300,
+              // 전체 라인은 테마에 따라 밝거나 어둡게
+              color: isDark ? Colors.grey.shade700 : Colors.grey.shade300,
             ),
             Align(
               alignment:
@@ -150,7 +163,10 @@ class DetailTabSelector extends StatelessWidget {
                       : Alignment.centerRight,
               child: FractionallySizedBox(
                 widthFactor: 0.5,
-                child: Container(height: 2, color: Colors.black),
+                child: Container(
+                  height: 2, // 선택된 탭 밑줄은 테마에 따라 색상 변경
+                  color: isDark ? Colors.white : Colors.black,
+                ),
               ),
             ),
           ],

--- a/lib/pages/detail/widgets/product_detail_page.dart
+++ b/lib/pages/detail/widgets/product_detail_page.dart
@@ -21,16 +21,25 @@ class DetailImageSection extends StatelessWidget {
 }
 
 ///상세페이지 정보 클래스
-class DetailInfoSection extends StatelessWidget {
+class DetailInfoSection extends StatefulWidget {
   final Product product;
   final QuantityController controller;
+  final double averageRating;
+  final int totalReviews;
 
   const DetailInfoSection({
     required this.product,
     required this.controller,
+    required this.averageRating,
+    required this.totalReviews,
     super.key,
   });
 
+  @override
+  State<DetailInfoSection> createState() => _DetailInfoSectionState();
+}
+
+class _DetailInfoSectionState extends State<DetailInfoSection> {
   String formatPrice(int price) {
     final formatter = NumberFormat('#,###');
     return formatter.format(price);
@@ -44,17 +53,26 @@ class DetailInfoSection extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            product.title,
+            widget.product.title,
             style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 8),
-          Row(children: [starScore(product.rate)]),
+          Row(
+            children: [
+              starScore(context, widget.averageRating),
+              SizedBox(width: 20),
+              Text(
+                '리뷰 ${widget.totalReviews}개',
+                style: TextStyle(fontSize: 12, color: Colors.grey),
+              ),
+            ],
+          ),
           const SizedBox(height: 8),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                '${formatPrice(controller.totalPrice)}원',
+                '${formatPrice(widget.controller.totalPrice)}원',
                 style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
               ),
 
@@ -62,12 +80,12 @@ class DetailInfoSection extends StatelessWidget {
                 children: [
                   IconButton(
                     icon: const Icon(Icons.remove),
-                    onPressed: controller.decrement,
+                    onPressed: widget.controller.decrement,
                   ),
-                  Text('${controller.quantity}'),
+                  Text('${widget.controller.quantity}'),
                   IconButton(
                     icon: const Icon(Icons.add),
-                    onPressed: () => controller.increment(context),
+                    onPressed: () => widget.controller.increment(context),
                   ),
                 ],
               ),
@@ -180,10 +198,12 @@ class DetailTabSelector extends StatelessWidget {
 class DetailContentView extends StatefulWidget {
   final int tabIndex;
   final Product product;
+  final Function(double averageRating, int totalReviews) onRatingChanged; //
 
   const DetailContentView({
     required this.tabIndex,
     required this.product,
+    required this.onRatingChanged,
     super.key,
   });
 
@@ -226,6 +246,11 @@ class _DetailContentViewState extends State<DetailContentView> {
     setState(() {
       _reviews.insert(0, newReview); // 최신순으로 추가
     });
+
+    /// 리뷰 추가 후 평균 별점 계산 & 상위 콜백 호출
+    final sum = _reviews.fold(0.0, (acc, r) => acc + r.rating);
+    final average = sum / _reviews.length;
+    widget.onRatingChanged(average, _reviews.length);
   }
 
   void _openReviewModal() {

--- a/lib/pages/detail/widgets/product_detail_page.dart
+++ b/lib/pages/detail/widgets/product_detail_page.dart
@@ -110,86 +110,63 @@ class DetailTabSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    ///현재 테마가 다크모드인지 확인
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    return Column(
-      children: [
-        // 탭 선택 영역
-        Row(
-          children: [
-            Expanded(
-              child: GestureDetector(
-                onTap: () => onTabChanged(0),
-                child: Column(
-                  children: [
-                    Text(
-                      '상품설명',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
+    return DefaultTabController(
+      length: 2,
+      initialIndex: selectedTab,
+      child: Builder(
+        builder: (context) {
+          final TabController tabController = DefaultTabController.of(context);
 
-                        ///선택된 탭일 때 다크모드는 흰색, 라이트모드는 검정색
-                        color:
-                            selectedTab == 0
-                                ? (isDark ? Colors.white : Colors.black)
-                                : Colors.grey,
-                      ),
+          // 탭 변경 시 콜백 호출
+          tabController.addListener(() {
+            if (!tabController.indexIsChanging &&
+                tabController.index != selectedTab) {
+              onTabChanged(tabController.index);
+            }
+          });
+
+          return Column(
+            children: [
+              TabBar(
+                controller: tabController,
+                tabs: const [Tab(text: '상품설명'), Tab(text: '리뷰')],
+                labelColor: isDark ? Colors.white : Colors.black,
+                unselectedLabelColor: Colors.grey,
+                labelStyle: const TextStyle(fontWeight: FontWeight.bold),
+                indicator: const BoxDecoration(),
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: Container(
+                      height: 1.2,
+                      color:
+                          selectedTab == 0
+                              ? (isDark ? Colors.white : Colors.black)
+                              : (isDark
+                                  ? Colors.grey.shade700
+                                  : Colors.grey.shade300),
                     ),
-                    const SizedBox(height: 8),
-                  ],
-                ),
-              ),
-            ),
-            Expanded(
-              child: GestureDetector(
-                onTap: () => onTabChanged(1),
-                child: Column(
-                  children: [
-                    Text(
-                      '리뷰',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        // 선택된 탭일 때 다크모드는 흰색, 라이트모드는 검정색
-                        color:
-                            selectedTab == 1
-                                ? (isDark ? Colors.white : Colors.black)
-                                : Colors.grey,
-                      ),
+                  ),
+                  Expanded(
+                    child: Container(
+                      height: 1.2,
+                      color:
+                          selectedTab == 1
+                              ? (isDark ? Colors.white : Colors.black)
+                              : (isDark
+                                  ? Colors.grey.shade700
+                                  : Colors.grey.shade300),
                     ),
-                    const SizedBox(height: 8),
-                  ],
-                ),
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
-        // 전체 라인 + 하이라인
-        Stack(
-          children: [
-            Container(
-              height: 2,
-              width: double.infinity,
-              // 전체 라인은 테마에 따라 밝거나 어둡게
-              color: isDark ? Colors.grey.shade700 : Colors.grey.shade300,
-            ),
-            Align(
-              alignment:
-                  selectedTab == 0
-                      ? Alignment.centerLeft
-                      : Alignment.centerRight,
-              child: FractionallySizedBox(
-                widthFactor: 0.5,
-                child: Container(
-                  height: 2, // 선택된 탭 밑줄은 테마에 따라 색상 변경
-                  color: isDark ? Colors.white : Colors.black,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ],
+            ],
+          );
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
### 🚀 개요
상세페이지 다크테마 적용,실시간 별점 변경 (리뷰등록에 따른),리뷰총숫자 텍스트 표시

### 🔧 변경사항
상세페이지 다크테마 적용,

실시간 별점 변경 (리뷰등록에 따른),

리뷰총숫자 텍스트 표시

탭바 컴포넌트로 변경

TabBar() 사용 → Flutter 기본 탭바 컴포넌트

DefaultTabController 래핑 → 자동으로 TabController 관리

탭 변경 시 addListener로 onTabChanged 콜백 호출 → 외부 상태 업데이트 가능

indicator는 제거하고, 대신 아래 직접 만든 커스텀 선으로 꾸밈

### 실행 화면
<img src="https://github.com/user-attachments/assets/7f2d79bc-fefe-4bc7-b7d4-909c68732442" width="300" height="600"/>

### 💡issue : #125 